### PR TITLE
Add TCP server/client examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Tug of War Prototype
 
-This is a small Unity prototype for a network-based two player tug-of-war game. One player hosts and shares their IP address, the other connects using that information. Players tap the screen rapidly during the match to pull the color toward their side.
+This is a small Unity prototype for a network-based two player tug-of-war game.
+One player hosts and shares their IP address, the other connects using that information.
+Players tap the screen rapidly during the match to pull the color toward their side.
 
-This project contains a single script `GameLoop.cs` that manages the UI, handles local taps and sends small network messages using `TcpClient`/`TcpListener`.
+This project originally contained a single script `GameLoop.cs` that manages the UI,
+handles local taps and sends small network messages using `TcpClient`/`TcpListener`.
+
+Additional standalone C# examples have been added in `TcpServer.cs` and
+`TcpClientExample.cs`. They demonstrate basic TCP server and client usage from a
+console application.

--- a/TcpClientExample.cs
+++ b/TcpClientExample.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Net.Sockets;
+using System.Text;
+
+public class TcpClientExample
+{
+    public static void Main(string[] args)
+    {
+        string host = "127.0.0.1";
+        int port = 5000;
+        string message = "Hello";
+
+        if (args.Length > 0)
+            host = args[0];
+        if (args.Length > 1 && int.TryParse(args[1], out int parsedPort))
+            port = parsedPort;
+        if (args.Length > 2)
+            message = args[2];
+
+        using (var client = new TcpClient())
+        {
+            client.Connect(host, port);
+            using (var stream = client.GetStream())
+            {
+                byte[] msgBytes = Encoding.UTF8.GetBytes(message);
+                stream.Write(msgBytes, 0, msgBytes.Length);
+
+                byte[] buffer = new byte[1024];
+                int bytesRead = stream.Read(buffer, 0, buffer.Length);
+                string response = Encoding.UTF8.GetString(buffer, 0, bytesRead);
+                Console.WriteLine($"Server replied: {response}");
+            }
+        }
+    }
+}

--- a/TcpServer.cs
+++ b/TcpServer.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+
+public class TcpServer
+{
+    public static void Main(string[] args)
+    {
+        int port = 5000;
+        if (args.Length > 0 && int.TryParse(args[0], out int parsedPort))
+        {
+            port = parsedPort;
+        }
+
+        var listener = new TcpListener(IPAddress.Any, port);
+        listener.Start();
+        Console.WriteLine($"Server listening on port {port}");
+
+        while (true)
+        {
+            Console.WriteLine("Waiting for client...");
+            using (var client = listener.AcceptTcpClient())
+            using (var stream = client.GetStream())
+            {
+                Console.WriteLine("Client connected");
+                byte[] buffer = new byte[1024];
+                int bytesRead = stream.Read(buffer, 0, buffer.Length);
+                string received = Encoding.UTF8.GetString(buffer, 0, bytesRead);
+                Console.WriteLine($"Received: {received}");
+
+                string response = "Echo: " + received;
+                byte[] responseBytes = Encoding.UTF8.GetBytes(response);
+                stream.Write(responseBytes, 0, responseBytes.Length);
+                Console.WriteLine("Response sent");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a standalone TCP server example
- add a standalone TCP client example
- document the examples in README

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68400608653083338a37da7c0bafe846